### PR TITLE
Fix Slack invitation URL

### DIFF
--- a/source/layouts/_footer.html.slim
+++ b/source/layouts/_footer.html.slim
@@ -8,7 +8,7 @@ footer.footer
     .flexbox.flexbox-center
       .social-link = link_to 'Meetup', 'https://www.meetup.com/fr-FR/Nantes-rb/', target: '_blank'
       | &#8226;
-      .social-link = link_to 'Slack', 'https://nantesrb.herokuapp.com/', target: '_blank'
+      .social-link = link_to 'Slack', 'https://join.slack.com/t/nantesrb/shared_invite/enQtNjg2MDM5NzQzNjE4LTQzMjg2NTc1MWZjZDY5N2Q3NTY1Y2M0NDI0ZTYxYjBmNWJkNTdlYjc5ZjAyYWQ0YTRiMTY2MTQ0YWM4MTFlNzQ', target: '_blank'
       | &#8226;
       .social-link = link_to 'GitHub', 'https://github.com/nantesrb', target: '_blank'
       | &#8226;


### PR DESCRIPTION
Le lien actuel pointe vers une app Heroku qui n'existe plus.
Je l'ai remplacé par le lien d'invite trouvé sur le site de Nantes.rb